### PR TITLE
Add 'mouse on NPC' filter for AutoClicker plugin

### DIFF
--- a/meteor-client/src/main/java/meteor/plugins/autoclicker/AutoClickerConfig.java
+++ b/meteor-client/src/main/java/meteor/plugins/autoclicker/AutoClickerConfig.java
@@ -266,4 +266,29 @@ public interface AutoClickerConfig extends Config
         return false;
     }
 
+    @ConfigItem(
+            keyName = "mouseOnNPC",
+            name = "Mouse On NPC",
+            description = "",
+            position = 22,
+            section = clickerFilters
+    )
+    default boolean mouseOnNPC()
+    {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "mouseOnNPCID",
+            name = "NPC ID",
+            description = "",
+            position = 23,
+            section = clickerFilters,
+            hidden = true,
+            unhide = "mouseOnNPC"
+    )
+    default int mouseOnNPCID()
+    {
+        return 0;
+    }
 }


### PR DESCRIPTION
New filter makes it so that the mouse must be inside a specified NPC's convex hull, in order to click.