### PR TITLE
Fix window bounds and resizing

### DIFF
--- a/meteor-client/src/main/java/meteor/MeteorLiteClientModule.java
+++ b/meteor-client/src/main/java/meteor/MeteorLiteClientModule.java
@@ -67,21 +67,8 @@ import meteor.eventbus.Subscribe;
 import meteor.eventbus.events.ClientShutdown;
 import meteor.events.ExternalsReloaded;
 import meteor.game.WorldService;
-import meteor.plugins.api.commons.Time;
-import meteor.plugins.api.entities.*;
 import meteor.plugins.api.game.*;
-import meteor.plugins.api.input.Keyboard;
-import meteor.plugins.api.input.Mouse;
-import meteor.plugins.api.items.Bank;
-import meteor.plugins.api.items.Equipment;
-import meteor.plugins.api.items.Inventory;
 import meteor.plugins.api.movement.Movement;
-import meteor.plugins.api.movement.Reachable;
-import meteor.plugins.api.movement.pathfinder.Walker;
-import meteor.plugins.api.packets.Packets;
-import meteor.plugins.api.scene.Tiles;
-import meteor.plugins.api.widgets.Dialog;
-import meteor.plugins.api.widgets.Widgets;
 import meteor.plugins.itemstats.ItemStatChangesService;
 import meteor.plugins.itemstats.ItemStatChangesServiceImpl;
 import meteor.ui.controllers.ToolbarFXMLController;
@@ -93,7 +80,6 @@ import meteor.util.ExecutorServiceExceptionLogger;
 import meteor.util.NonScheduledExecutorServiceExceptionLogger;
 import meteor.util.WorldUtil;
 import net.runelite.api.Client;
-import net.runelite.api.TileItem;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.hooks.Callbacks;
 import net.runelite.http.api.chat.ChatClient;
@@ -106,6 +92,12 @@ public class MeteorLiteClientModule extends AbstractModule implements AppletStub
 
   public static String uuid = UUID.randomUUID().toString();
   public static JFrame mainWindow;
+
+  private static final int GAME_WINDOW_MIN_WIDTH = 765;
+  private static final int GAME_WINDOW_MIN_HEIGHT = 503;
+
+  private static final int TOOLBAR_HEIGHT = 33;
+  private static final int RIGHT_PANEL_LENGTH = 350;
 
   @Inject
   private EventBus eventBus;
@@ -252,19 +244,20 @@ public class MeteorLiteClientModule extends AbstractModule implements AppletStub
     overlayManager.add(tooltipOverlay.get());
 
     applet = (Applet) client;
-    applet.setSize(1280, 720);
+    applet.setMinimumSize(new Dimension(GAME_WINDOW_MIN_WIDTH, GAME_WINDOW_MIN_HEIGHT));
     setAppletConfiguration(applet);
 
     //Early init game panel so gpu doesn't eat shit when enabling
     JPanel gamePanel = new JPanel();
     rootPanel.setLayout(new BorderLayout());
-    gamePanel.setSize(800, 600);
+    gamePanel.setMinimumSize(new Dimension(GAME_WINDOW_MIN_WIDTH, GAME_WINDOW_MIN_HEIGHT));
     toolbarRoot = FXMLLoader.load(
             Objects.requireNonNull(ClassLoader.getSystemClassLoader().getResource("toolbar.fxml")));
 
     gamePanel.setLayout(new BorderLayout());
     gamePanel.add(applet, BorderLayout.CENTER);
     rootPanel.add(gamePanel, BorderLayout.CENTER);
+    rootPanel.setMinimumSize(new Dimension(GAME_WINDOW_MIN_WIDTH, GAME_WINDOW_MIN_HEIGHT));
 
     configManager.load();
     pluginManager.startInternalPlugins();
@@ -289,16 +282,22 @@ public class MeteorLiteClientModule extends AbstractModule implements AppletStub
 
     pluginsPanelVisible = !pluginsPanelVisible;
     if (pluginsPanelVisible) {
-      mainWindow.setMinimumSize(new Dimension(1280, 720));
+      mainWindow.setMinimumSize(new Dimension(GAME_WINDOW_MIN_WIDTH + (GAME_WINDOW_MIN_WIDTH - 749) + RIGHT_PANEL_LENGTH, GAME_WINDOW_MIN_HEIGHT + (GAME_WINDOW_MIN_HEIGHT - 464) + TOOLBAR_HEIGHT));
       mainWindow.validate();
-    }
-    else
+    } else {
       setMinimumFrameSize();
+    }
   }
 
   private static void setMinimumFrameSize() {
-    mainWindow.setMinimumSize(new Dimension(780, 575));
-    mainWindow.validate();
+    // The numbers 749 and 464 come from the main windows content pane when the min size is set to the osrs client resolution (765x503).
+    // So we adjust the main window to be large enough to fit those bounds inside the content pane.
+      boolean resize = mainWindow.getSize().equals(mainWindow.getMinimumSize());
+      mainWindow.setMinimumSize(new Dimension(GAME_WINDOW_MIN_WIDTH + (GAME_WINDOW_MIN_WIDTH - 749), GAME_WINDOW_MIN_HEIGHT + (GAME_WINDOW_MIN_HEIGHT - 464) + TOOLBAR_HEIGHT));
+      if (resize) {
+        mainWindow.setSize(mainWindow.getMinimumSize());
+      }
+      mainWindow.validate();
   }
 
   public static void showPlugins() throws IOException {
@@ -319,7 +318,6 @@ public class MeteorLiteClientModule extends AbstractModule implements AppletStub
   public static void setupJavaFXComponents(Applet applet) throws IOException {
 
     mainWindow = new JFrame();
-    mainWindow.setSize(780, 575);
     setMinimumFrameSize();
     JFXPanel toolbarPanel = new JFXPanel();
     toolbarPanel.setSize(1280, 100);


### PR DESCRIPTION
This fixes the minimum bounds so that the embedded client will never get cut off and also makes it so that the plugin panel expanding doesn't increase the height and introduce black bars. Also if the client is at the minimum size when the panel is collapsed it will resize back to the minimum so that it doesn't leave black bars as well.

![Animation](https://user-images.githubusercontent.com/2768746/132109002-7916f697-5831-43a2-ba47-479d20994bc3.gif)
