### PR TITLE
Calculate path distance and cache Teleport/Transport lists

### DIFF
--- a/meteor-client/src/main/java/meteor/plugins/api/movement/Movement.java
+++ b/meteor-client/src/main/java/meteor/plugins/api/movement/Movement.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.awt.*;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -225,5 +226,31 @@ public class Movement {
 
     public static boolean isStaminaBoosted() {
         return Vars.getBit(STAMINA_VARBIT) == 1;
+    }
+
+    public static int calculateDistance(WorldPoint destination) {
+        List<WorldPoint> path = Walker.buildPath(destination);
+
+        if (path.size() < 2) {
+            return 0;
+        }
+
+        Iterator<WorldPoint> it = path.iterator();
+        WorldPoint prev = it.next();
+        WorldPoint current;
+        int distance = 0;
+
+        // WorldPoint#distanceTo() returns max int when planes are different, but since the pathfinder can traverse
+        // obstacles, we just add one to the distance to account for whatever obstacle is in between the current point
+        // and the next.
+        while (it.hasNext()) {
+            current = it.next();
+            if (prev.getPlane() != current.getPlane()) {
+                distance += 1;
+            } else {
+                distance += Math.max(Math.abs(prev.getX() - current.getX()), Math.abs(prev.getY() - current.getY()));
+            }
+        }
+        return distance;
     }
 }

--- a/meteor-client/src/main/java/meteor/plugins/api/movement/pathfinder/BankLocation.java
+++ b/meteor-client/src/main/java/meteor/plugins/api/movement/pathfinder/BankLocation.java
@@ -1,7 +1,7 @@
 package meteor.plugins.api.movement.pathfinder;
 
+import meteor.plugins.api.movement.Movement;
 import net.runelite.api.coords.WorldArea;
-import net.runelite.api.coords.WorldPoint;
 
 import java.util.Arrays;
 import java.util.Comparator;
@@ -54,9 +54,9 @@ public enum BankLocation {
         return area;
     }
 
-    public static BankLocation getNearest(WorldPoint worldPoint) {
+    public static BankLocation getNearest() {
         return Arrays.stream(values())
-                .min(Comparator.comparingInt(x -> x.getArea().distanceTo(worldPoint)))
+                .min(Comparator.comparingInt(x -> Movement.calculateDistance(x.getArea().toWorldPoint())))
                 .orElse(null);
     }
 }

--- a/meteor-client/src/main/java/meteor/plugins/api/movement/pathfinder/TeleportLoader.java
+++ b/meteor-client/src/main/java/meteor/plugins/api/movement/pathfinder/TeleportLoader.java
@@ -16,13 +16,13 @@ import net.runelite.api.widgets.Widget;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 public class TeleportLoader {
     private static final int BUILD_DELAY_SECONDS = 5;
-    private static Instant lastBuild = Instant.now();
+    private static Instant lastBuild = Instant.now().minusSeconds(6);
+    private static List<Teleport> LAST_TELEPORT_LIST = Collections.emptyList();
     private static final int[] RING_OF_DUELING = new int[]{2552, 2554, 2556, 2558, 2560, 2562, 2564, 2566};
     private static final int[] GAMES_NECKLACE = new int[]{3853, 3863, 3855, 3857, 3859, 3861, 3863, 3865, 3867};
     private static final int[] COMBAT_BRACELET = new int[]{11118, 11972, 11974, 11120, 11122, 11124};
@@ -38,7 +38,7 @@ public class TeleportLoader {
 
     public static List<Teleport> buildTeleports() {
         if (lastBuild.plusSeconds(BUILD_DELAY_SECONDS).isAfter(Instant.now())) {
-            return Collections.emptyList();
+            return List.copyOf(LAST_TELEPORT_LIST);
         }
 
         lastBuild = Instant.now();
@@ -149,8 +149,8 @@ public class TeleportLoader {
                 }
             }
         }
-
-        return teleports;
+        LAST_TELEPORT_LIST = teleports;
+        return List.copyOf(LAST_TELEPORT_LIST);
     }
 
     public static void jewelryTeleport(String target, int... ids) {

--- a/meteor-client/src/main/java/meteor/plugins/api/movement/pathfinder/TransportLoader.java
+++ b/meteor-client/src/main/java/meteor/plugins/api/movement/pathfinder/TransportLoader.java
@@ -1,6 +1,5 @@
 package meteor.plugins.api.movement.pathfinder;
 
-import meteor.plugins.api.commons.Time;
 import meteor.plugins.api.entities.NPCs;
 import meteor.plugins.api.entities.TileObjects;
 import meteor.plugins.api.game.Skills;
@@ -24,10 +23,11 @@ import java.util.List;
 public class TransportLoader {
     private static final int BUILD_DELAY_SECONDS = 5;
     private static Instant lastBuild = Instant.now().minusSeconds(6);
+    private static List<Transport> LAST_TRANSPORT_LIST = Collections.emptyList();
 
     public static List<Transport> buildTransports() {
         if (lastBuild.plusSeconds(BUILD_DELAY_SECONDS).isAfter(Instant.now())) {
-            return Collections.emptyList();
+            return List.copyOf(LAST_TRANSPORT_LIST);
         }
 
         lastBuild = Instant.now();
@@ -164,7 +164,8 @@ public class TransportLoader {
                 1164,
                 "Well that is a risk I will have to take."));
 
-        return transports;
+        LAST_TRANSPORT_LIST = transports;
+        return List.copyOf(LAST_TRANSPORT_LIST);
     }
 
     public static Transport parseTransportLine(String line) {


### PR DESCRIPTION
If you build more than one path in less than 5 seconds you'll get an empty path. This saves the last built teleport/transport list and returns a copy of them instead of an empty list. Also adds a util function in Movement for getting the distance of a path which is useful for getting the nearest WorldPoint (for example finding the nearest bank).